### PR TITLE
Send FIN packet to vxlan tunnel, make sure conntrack not established on host

### DIFF
--- a/tc_prog/common_kern.h
+++ b/tc_prog/common_kern.h
@@ -26,6 +26,9 @@ int parse_5tuple_in(struct iphdr * iph, void *data_end, struct fivetuple* tuple)
     tuple->protocol = iph->protocol;
     if (proto == IPPROTO_TCP) {
         struct tcphdr *tcphdr = (struct tcphdr *)(iph + 1);
+	if (tcphdr->fin) {
+	    return 1;
+	}
         tuple->rport = tcphdr->source;
         tuple->lport = tcphdr->dest;
     } else if (proto == IPPROTO_UDP) {
@@ -50,6 +53,9 @@ int parse_5tuple_e(struct iphdr * iph, void *data_end, struct fivetuple* tuple) 
     tuple->protocol = iph->protocol;
     if (proto == IPPROTO_TCP) {
         struct tcphdr *tcphdr = (struct tcphdr *)(iph + 1);
+	if (tcphdr->fin) {
+	    return 1;
+	}
         tuple->lport = tcphdr->source;
         tuple->rport = tcphdr->dest;
     } else if (proto == IPPROTO_UDP) {


### PR DESCRIPTION
After enabling the oncache feature, if the FIN packet uses the oncache fast path instead of the standard VXLAN path, it will cause the conntrack information on the node to still show as "established". Therefore, the FIN packet should be transmitted via the standard VXLAN path.